### PR TITLE
Adds API route for retrieving quote IDs

### DIFF
--- a/crates/cdk-axum/Cargo.toml
+++ b/crates/cdk-axum/Cargo.toml
@@ -15,6 +15,7 @@ axum = { version = "0.6.20", features = ["ws"] }
 cdk = { path = "../cdk", version = "0.7.1", default-features = false, features = [
     "mint",
 ] }
+cdk-common = { path = "../cdk-common", version = "0.7.1" }
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",

--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -18,6 +18,7 @@ mod ws;
 
 #[cfg(feature = "swagger")]
 mod swagger_imports {
+    pub use crate::router_handlers::{QuotesSharesQuery, QuotesSharesResponse};
     pub use cdk::amount::Amount;
     pub use cdk::error::{ErrorCode, ErrorResponse};
     pub use cdk::nuts::nut00::{
@@ -99,6 +100,8 @@ pub struct MintState {
         ProofDleq,
         ProofState,
         PublicKey,
+        QuotesSharesQuery,
+        QuotesSharesResponse,
         RestoreRequest,
         RestoreResponse,
         SecretKey,
@@ -125,7 +128,8 @@ pub struct MintState {
         post_melt_bolt11,
         post_swap,
         post_check,
-        post_restore
+        post_restore,
+        get_quotes_shares
     )
 )]
 /// OpenAPI spec for the mint's v1 APIs
@@ -167,7 +171,8 @@ pub async fn create_mint_router_with_custom_cache(
         .route("/melt/bolt11", post(cache_post_melt_bolt11))
         .route("/checkstate", post(post_check))
         .route("/info", get(get_mint_info))
-        .route("/restore", post(post_restore));
+        .route("/restore", post(post_restore))
+        .route("/mint/quote-ids/share", get(get_quotes_shares));
 
     let mint_router = Router::new().nest("/v1", v1_router).with_state(state);
 

--- a/crates/cdk-axum/src/lib.rs
+++ b/crates/cdk-axum/src/lib.rs
@@ -18,7 +18,7 @@ mod ws;
 
 #[cfg(feature = "swagger")]
 mod swagger_imports {
-    pub use crate::router_handlers::{QuotesSharesQuery, QuotesSharesResponse};
+    pub use cdk_common::{QuotesSharesQuery, QuotesSharesResponse};
     pub use cdk::amount::Amount;
     pub use cdk::error::{ErrorCode, ErrorResponse};
     pub use cdk::nuts::nut00::{

--- a/crates/cdk-axum/src/router_handlers.rs
+++ b/crates/cdk-axum/src/router_handlers.rs
@@ -11,8 +11,8 @@ use cdk::nuts::{
     SwapRequest, SwapResponse,
 };
 use cdk::util::unix_time;
+use cdk_common::{QuotesSharesQuery, QuotesSharesResponse};
 use paste::paste;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::instrument;
 use uuid::Uuid;
@@ -409,18 +409,6 @@ pub async fn post_restore(
     })?;
 
     Ok(Json(restore_response))
-}
-
-#[derive(Debug, Deserialize)]
-pub struct QuotesSharesQuery {
-    /// Comma-separated list of share hashes
-    pub share_hashes: String,
-}
-
-#[derive(Debug, Serialize)]
-pub struct QuotesSharesResponse {
-    /// Share hash -> quote ID mapping
-    pub quote_ids: HashMap<String, String>,
 }
 
 #[cfg_attr(feature = "swagger", utoipa::path(

--- a/crates/cdk-common/src/common.rs
+++ b/crates/cdk-common/src/common.rs
@@ -1,5 +1,6 @@
 //! Types
 
+use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
@@ -171,6 +172,20 @@ impl QuoteTTL {
     pub fn new(mint_ttl: u64, melt_ttl: u64) -> QuoteTTL {
         Self { mint_ttl, melt_ttl }
     }
+}
+
+/// Query parameters for getting quote IDs from share hashes
+#[derive(Debug, Deserialize)]
+pub struct QuotesSharesQuery {
+    /// Comma-separated list of share hashes
+    pub share_hashes: String,
+}
+
+/// Response containing quote ID mappings for share hashes
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuotesSharesResponse {
+    /// Share hash -> quote ID mapping
+    pub quote_ids: HashMap<String, String>,
 }
 
 #[cfg(test)]

--- a/crates/cdk-common/src/lib.rs
+++ b/crates/cdk-common/src/lib.rs
@@ -7,6 +7,7 @@
 //! internal crates.
 
 pub mod common;
+pub use common::{QuotesSharesQuery, QuotesSharesResponse};
 pub mod database;
 pub mod error;
 #[cfg(feature = "mint")]


### PR DESCRIPTION
### Description

This PR adds a new GET endpoint to support fetching quote IDs for a given set of share hashes in HashPool. Currently, the pool, mint, and translator proxies are sharing state via Redis but since miners in general will not have access to Redis directly we need a standard way for them to share the quote UUID <-> share hash mapping.

-----

### Notes to the reviewers

The redis client is initialized on each request which is ok for local development and testing but in a production environment we will want to reuse the connection, consider reconnect logic, etc. I wasn't sure the best way to handle that in its current state.

-----

### Suggested [CHANGELOG](https://github.com/cashubtc/cdk/blob/main/CHANGELOG.md) Updates

<!-- Please do not edit the actual changelog but note what you changed here. -->

#### CHANGED

#### ADDED

Adds a `/v1/mint/quote-ids/share` route for looking up quote IDs from share hashes.

#### REMOVED

#### FIXED

----

### Checklist

* [x] I followed the [code style guidelines](https://github.com/cashubtc/cdk/blob/main/CODE_STYLE.md)
* [ ] I ran `just final-check` before committing
